### PR TITLE
Made Postgres Operator Compatible with Redshift

### DIFF
--- a/ewah/operators/postgres_operator.py
+++ b/ewah/operators/postgres_operator.py
@@ -7,7 +7,7 @@ class EWAHPostgresOperator(EWAHSQLBaseOperator):
     _SQL_BASE = \
         'SELECT\n{columns}\nFROM "{schema}"."{table}"\nWHERE {where_clause}'
     _SQL_BASE_SELECT = \
-        'WITH raw AS ({select_sql}) SELECT * FROM raw WHERE {{0}}'
+        'WITH raw_data AS ({select_sql}) SELECT * FROM raw_data WHERE {{0}}'
     _SQL_COLUMN_QUOTE = '"'
     _SQL_MINMAX_CHUNKS = '''
         WITH base AS ({base})


### PR DESCRIPTION
made naming so that it does not crash on redshift. The wording raw is protected in redshift:
https://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html