### PR TITLE
Pin setuptools version to <71

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ USER airflow
 ### <= --------------------------------------------- run as root ##
 
 
-RUN pip install --user --upgrade --no-cache-dir pip setuptools
+RUN pip install --user --upgrade --no-cache-dir pip 'setuptools<71'
 
 # required to make Oracle work with airflow user
 RUN sudo ldconfig /opt/oracle/instantclient_19_8


### PR DESCRIPTION
### Context 
EWAH image build [failed with error](https://github.com/Gemma-Analytics/ewah/actions/runs/11014146805/job/30584125298):
```
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```

[This answer](https://github.com/pypa/setuptools/issues/4483) pointed to the need to pin `setuptools` version to before 71.

### Changes
- Pin setuptools to <71

Once it is merged I'm going to re-trigger the failed job manually.