### PR TITLE
Fix Pipedrive Hook

### DIFF
--- a/ewah/hooks/pipedrive.py
+++ b/ewah/hooks/pipedrive.py
@@ -41,7 +41,9 @@ class EWAHPipedriveHook(EWAHBaseHook):
             result = request.json()
             success = request.status_code == 200 and result.get("success")
             if success:
-                if int(request.headers[self._REQUESTS_LEFT]) < 10:
+                # AS of 2025-08-19, the rate limit parameters do not exist, therefore we add a fallback
+                # Potentially, this code is not needed anymore, but we kept it in case the parameters show up again.
+                if int(request.headers[self._REQUESTS_LEFT], 10) < 10:
                     # Wait for ratelimit to fill up again
                     time.sleep(2)
 


### PR DESCRIPTION
Right now, there is no news on why this changed, but the Pipedrive API calls do not return any x-ratelimits, therefore our calls are failing.

- [Pipedrive API response headers for ratelimits](https://pipedrive.readme.io/docs/core-api-concepts-rate-limiting#http-headers-and-response-codes)
- [Pipedrive API changelog](https://developers.pipedrive.com/changelog)