### PR TITLE
Add explicit pandas extra to snowflake python connector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,14 @@ setuptools.setup(
         "recurly",
         "selenium",
         "simple-salesforce",
-        "snowflake-connector-python>=2.3.8",  # 2.3.8 vendored urrlib3 and requests
+        
+        # Snowflake connector dependencies (ref: https://stackoverflow.com/a/76463170)
+        "snowflake-connector-python[pandas]",
+        "pyarrow",
+        "pandas",
+        "sqlalchemy",
+        "snowflake-sqlalchemy",
+        
         "sshtunnel>=0.2.2",
         "stripe",
         "virtualenv",


### PR DESCRIPTION
We are seeing the error below that is breaking the deployment in Lightsail

```
 /home/airflow/.local/lib/python3.8/site-packages/snowflake/connector/options.py:96 UserWarning: You have an incompatible version of 'pyarrow' installed (6.0.1), please install a version that adheres to: 'pyarrow<8.1.0,>=8.0.0; extra == "pandas"'
```

Using this [reference ](https://stackoverflow.com/a/76463170) to adjust the list of dependencies

- Add pandas extra
- Add other related packages on the top level, so that pip will do the resolution