### PR TITLE
snowflake: map Python timedelta to NUMBER(38, 6) seconds

### DIFF
--- a/ewah/cleaner.py
+++ b/ewah/cleaner.py
@@ -11,6 +11,7 @@ from hashlib import sha256
 from bson.json_util import dumps  # dumping mongob objects to string
 from bson.objectid import ObjectId
 from collections import OrderedDict
+from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -240,6 +241,12 @@ class EWAHCleaner(LoggingMixin):
                     value = float(value)
                 elif isinstance(value, UUID):
                     value = str(value)
+                elif isinstance(value, timedelta):
+                    # Preserve `timedelta` as the inferred type (so the engine-
+                    # specific mapping is honored) but coerce the value to a
+                    # number of seconds for binding to numeric warehouse columns.
+                    value_type = timedelta
+                    value = value.total_seconds()
                 row[key] = value
 
                 # Set the fields_definition for the key

--- a/ewah/constants/__init__.py
+++ b/ewah/constants/__init__.py
@@ -94,6 +94,9 @@ class EWAHConstants:
             bool: "BOOLEAN",
             datetime: "TIMESTAMP_TZ",
             date: "DATE",
+            # Snowflake has no native INTERVAL column type; durations are
+            # represented as total seconds (microsecond resolution).
+            timedelta: "NUMBER(38, 6)",
             UUID: "TEXT",
         },
         DWH_ENGINE_BIGQUERY: {


### PR DESCRIPTION
Loading any Postgres `interval` column (or any other source that returns Python `datetime.timedelta` values) into a Snowflake target currently raises:

    Exception: Field '<col>' has an invalid data type
               '<class 'datetime.timedelta'>'!

because `QBC_TYPE_MAPPING[snowflake]` has no entry for `timedelta`.

Snowflake has no native `INTERVAL` column type, so the natural representation for a duration is a number of seconds. This patch:

- Adds `timedelta: "NUMBER(38, 6)"` to the Snowflake mapping in `ewah/constants/__init__.py`. Microsecond precision in the fractional part is enough to round-trip the resolution that `datetime.timedelta.total_seconds()` exposes.
- Adds a `timedelta` branch to `EWAHCleaner.clean_values` that coerces the value via `value.total_seconds()` while preserving `timedelta` as the inferred `value_type`, so the engine-specific mapping is honored (analogous to the existing dict/list branch that sets `value_type`).

Postgres mapping already had `timedelta: "interval"` and is unchanged. BigQuery mapping still has no `timedelta` entry; deliberately out of scope for this PR (BQ has a native INTERVAL type since 2022 — that deserves its own change).