### PR TITLE
Enable client_session_keep_alive on Snowflake hook to survive long tasks

### DIFF
--- a/ewah/hooks/snowflake.py
+++ b/ewah/hooks/snowflake.py
@@ -105,13 +105,7 @@ class EWAHSnowflakeHook(EWAHBaseHook):
             }
 
         if not hasattr(self, "_snow_conn"):
-            # Keep the session alive across long-running tasks. Without this,
-            # key-pair (JWT) auth fails on operations that run longer than the
-            # 60-minute JWT lifetime, because the original JWT signed at
-            # connect-time expires mid-task. With keep-alive, the connector
-            # transparently sends `/session/heartbeat` requests (~every 15 min,
-            # clamped by the connector) that refresh the JWT in the background.
-            # Harmless for short-lived tasks and for password auth.
+            # Keeps the Snowflake session alive via background heartbeats; prevents mid-task auth failure when key-pair JWT expires after 60 min.
             connection_params["client_session_keep_alive"] = True
             self._snow_conn = snowflake.connector.connect(**connection_params)
 

--- a/ewah/hooks/snowflake.py
+++ b/ewah/hooks/snowflake.py
@@ -105,6 +105,14 @@ class EWAHSnowflakeHook(EWAHBaseHook):
             }
 
         if not hasattr(self, "_snow_conn"):
+            # Keep the session alive across long-running tasks. Without this,
+            # key-pair (JWT) auth fails on operations that run longer than the
+            # 60-minute JWT lifetime, because the original JWT signed at
+            # connect-time expires mid-task. With keep-alive, the connector
+            # transparently sends `/session/heartbeat` requests (~every 15 min,
+            # clamped by the connector) that refresh the JWT in the background.
+            # Harmless for short-lived tasks and for password auth.
+            connection_params["client_session_keep_alive"] = True
             self._snow_conn = snowflake.connector.connect(**connection_params)
 
         return self._snow_conn


### PR DESCRIPTION
## Summary

Long-running ELT tasks using key-pair (JWT) auth on the EWAH Snowflake hook fail mid-task once the task runs longer than ~60 minutes — Snowflake caps JWT validity at 60 min and the connector does not refresh the JWT on its own, so the connection opened at task start dies before the task's final write.

Real-world trigger: Amazon Brand Analytics Search Query Performance loads where Amazon's report-ready polling stretches a task to 1–4 hours, and the closing \`COPY INTO\` then hits \`JWT token is invalid\` / \`Authentication token has expired\`.

## Changes

- \`ewah/hooks/snowflake.py\`: pass \`client_session_keep_alive=True\` to \`snowflake.connector.connect\`. The connector then runs a background heartbeat (~every 15 min, connector-clamped minimum) that refreshes the JWT and resets the session's idle timer for the lifetime of the connection.
- No effect on short-lived tasks or password-auth setups.