### PR TITLE
fix(ci): align Claude workflow triggers with central .github docs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,9 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   id-token: write
@@ -12,6 +14,13 @@ permissions:
 
 jobs:
   review:
+    # Draft PRs are skipped on 'opened' and reviewed once when marked ready —
+    # otherwise a PR opened as draft gets reviewed twice (opened + ready_for_review).
+    if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '@claude review'))
     uses: Gemma-Analytics/.github/.github/workflows/claude-review.yml@main
     with:
       additional_instructions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,8 +17,12 @@ permissions:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !startsWith(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !startsWith(github.event.comment.body, '@claude review')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     uses: Gemma-Analytics/.github/.github/workflows/claude.yml@main
     secrets: inherit


### PR DESCRIPTION
## What

Aligns both Claude workflow wrappers with the documented versions in [Gemma-Analytics/.github](https://github.com/Gemma-Analytics/.github):

- **`claude-review.yml`**: trigger on `pull_request: [opened, ready_for_review]` + `issue_comment` instead of `[opened, synchronize]`. Adds the documented `startsWith(comment.body, '@claude review')` comment guard and the draft-PR guard (adopted from gemma-infrastructure) so draft PRs are reviewed once, when marked ready.
- **`claude.yml`**: adds the `!startsWith(..., '@claude review')` routing guard so review requests route to the review workflow rather than the general assistant.

## Why

Investigating the repeated review rounds on https://github.com/Gemma-Analytics/ewah/pull/326 showed:

1. The wrapper's `synchronize` trigger re-ran a **full one-shot review on every push** — the review that appeared on 2026-08-10 at 11:56 was triggered by the 11:35 push (run duration 1251s matches the cost comment), not by the comment quoting the review footer. The central review prompt is explicitly designed as one-shot ("new commits do NOT retrigger it"), so `synchronize` contradicts it and is the source of the never-ending review iterations.
2. The wrapper had **no `issue_comment` trigger at all**, so the advertised `@claude review` command silently did nothing in this repo.
3. Quoted footers ("> ... commenting `@claude review`") cannot retrigger reviews with the documented guard, since quoted lines start with `>` and the guard uses `startsWith`.

After this change: reviews fire on PR open (non-draft), on draft → ready, and on explicit `@claude review` comments — never on pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)